### PR TITLE
Add version file

### DIFF
--- a/SSTOProject/SSTOProject.version
+++ b/SSTOProject/SSTOProject.version
@@ -1,0 +1,25 @@
+{
+    "NAME":     "SSTO Project",
+    "ULR":      "https://github.com/Monniasza/SSTO-Project/raw/master/SSTOProject/SSTOProject.version",
+    "DOWNLOAD": "https://github.com/Monniasza/SSTO-Project/releases/download/1.3.3/SSTOProject.1.3.3.zip",
+    "GITHUB": {
+        "USERNAME":          "Monniasza",
+        "REPOSITORY":        "SSTO-Project",
+        "ALLOW_PRE_RELEASE": false
+    },
+    "VERSION": {
+        "MAJOR": 1,
+        "MINOR": 3,
+        "PATCH": 3
+    },
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 8,
+        "PATCH": 0
+    },
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 9,
+        "PATCH": 1
+    }
+}


### PR DESCRIPTION
See KSP-CKAN/CKAN-meta#2150, the current version of this mod is supported on KSP 1.8.0–1.9.1.
This PR adds a version file indicating that. The syntax is documented here:

- http://ksp.cybutek.net/kspavc/Documents/README.htm

NOTE, you will need to:
- Add this file to **the release download ZIP**! Simply merging into the repo is not enough!
- Update the version file each time you make a new release! A release with a bad version file causes many problems!