### PR TITLE
Extra bracket found in the code

### DIFF
--- a/SSTOLPG/ConverterB9.cfg
+++ b/SSTOLPG/ConverterB9.cfg
@@ -83,7 +83,7 @@ B9ConverterConfigs{
 @PART[*]:HAS[~b9mastertoggle[true]]{
 	%b9celigible = false;
 }
-@PART[*]:HAS[!MODULE[B9PartSwitch]:HAS[@SUBTYPE]:HAS[#tankType],#b9celigible[true]]]{
+@PART[*]:HAS[!MODULE[B9PartSwitch]:HAS[@SUBTYPE]:HAS[#tankType],#b9celigible[true]]{
 	MODULE{
 		name = ModuleB9PartSwitch
 		moduleID = UPCFuelTanks


### PR DESCRIPTION
When attempting to run the lpg converter i received errors preventing me from loading the game.

I traced the source of this to this error
"Error - node name does not have balanced brackets (or a space - if so replace with ?): SSTOLPG/ConverterB9/@PART[*]:HAS[!MODULE[B9PartSwitch]:HAS[@SUBTYPE]:HAS[#tankType],#b9celigible[true]]]"

this error corresponded to an extra bracket on line 86.